### PR TITLE
Update IcePartial2.py

### DIFF
--- a/cupcake2/ice2/IcePartial2.py
+++ b/cupcake2/ice2/IcePartial2.py
@@ -367,8 +367,9 @@ class IcePartialOne2(object):
                                                no_qv_or_aln_checking=False,
                                                tmp_dir=self.tmp_dir,
                                                sID_starts_with_c=sID_starts_with_c)
-            except:
+            except Exception:
                 # fall back to blasr
+                logging.exception('Daligner failed. Falling back to blasr.')
                 self.ice_opts.aligner_choice = 'blasr'
                 self.run()
         elif self.ice_opts.aligner_choice == 'blasr':


### PR DESCRIPTION
For several reasons, I had trouble find the code-path to a warning. Now that I've found it, I want to be sure that it is more debuggable in the future.

1) Bare "except" in Python can trap `SyntaxError` and `KeyboardInterrupt`, so it is better to trap `Exception`, the base of the non-system hierarchy.
2) Since the exception is not re-raised, it can be helpful to log it. Minimally, we should log a warning about the fallback to blasr, but since the stack-trace was so hard for me to find, in this case logging the entire exception seems to make sense.

The PB servers/VPN are having trouble tonight, so I am just trying to get some work done in GitHub. If cDNA is also in BitBucket, then I will push this into BB when possible and rebase `master` here later.

* https://jira.pacificbiosciences.com/browse/TAG-1643