### PR TITLE
Fix reading of PBIDs from count file in chain_fusion_samples.py

### DIFF
--- a/cupcake/tofu/counting/chain_fusion_samples.py
+++ b/cupcake/tofu/counting/chain_fusion_samples.py
@@ -33,7 +33,12 @@ def sample_sanity_check(group_filename, gff_filename, count_filename, fastq_file
     ids1 = [line.strip().split()[0] for line in open(group_filename)]
     ids2 = [fusion_id for fusion_id,rs in GFF.collapseGFFFusionReader(gff_filename)]
     f = open(count_filename)
-    for i in range(14): f.readline() # just through the header
+    while True:
+        # advance through the headers which start with #
+        cur = f.tell()
+        if not f.readline().startswith('#') or f.tell() == cur:  # first non-# seen or EOF
+            f.seek(cur)
+            break
     ids3 = [r['pbid'] for r in DictReader(f, delimiter='\t')]
     if len(set(ids2).difference(ids1))>0 or len(set(ids2).difference(ids3))>0:
         raise Exception("Sanity check failed! Please make sure the PBIDs listed in {1} are also in {0} and {2}".format(\


### PR DESCRIPTION
When running `chain_fusion_samples.py` by providing a count file generated from `fusion_finder.py`, the script fails at the `sample_sanity_check` step, as it is unable to correctly read the count PBIDs:
```
File "~/.conda/envs/SQANTI3.env/lib/python3.7/site-packages/cupcake-12.5.0-py3.7-linux-x86_64.egg/EGG-INFO/scripts/chain_fusion_samples.py", line 37, in <listcomp>
    ids3 = [r['pbid'] for r in DictReader(f, delimiter='\t')]
KeyError: 'pbid'
```

In `chain_samples.py` this step works correctly, as the code advances through the headers until the first non-#:
https://github.com/Magdoll/cDNA_Cupcake/blob/e6a09fccf93c8e08b77fc3c027dbdb888449ec7c/cupcake/tofu/counting/chain_samples.py#L23-L30

However, in `chain_fusion_samples.py` the function skips the first 14 lines of the file, which causes the parsing error (the header appears to be 8 lines long):
https://github.com/Magdoll/cDNA_Cupcake/blob/e6a09fccf93c8e08b77fc3c027dbdb888449ec7c/cupcake/tofu/counting/chain_fusion_samples.py#L35-L37

Replacing the code from `chain_samples.py` into `chain_fusion_samples.py` appears to solve the issue.