### PR TITLE
Making collapse_isoforms_by_sam.py compatible with SAM file multiprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.pyc
 *.so
+*.swp
 
 build/*
 cupcake/tofu/branch/*


### PR DESCRIPTION
The logic wasn't in place to multiprocess SAMs, and the infrastructure that was there for parsing the SAM needed a small workaround. I'm not sure if saying the file is a BAM instead of a SAM will be a problem in the future, but it should fix #180 